### PR TITLE
Add .css file as a main bower file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "alexanderbeletsky <alexander.beletsky@gmail.com>"
   ],
   "description": "Angular.js component for stylish and flexible application notifications.",
-  "main": "dist/ngNotificationsBar.min.js",
+  "main": ["dist/ngNotificationsBar.min.js", "dist/ngNotificationsBar.min.css"],
   "moduleType": [
     "globals"
   ],


### PR DESCRIPTION
At the moment Bower doesn't know about the required CSS file, which can cause headaches for auto-compiling/linking dependencies. Adding it as a main file means that any bower helpers will start to pick it up.