### PR TITLE
Fixed bower dependency

### DIFF
--- a/sass/ngNotificationsBar.scss
+++ b/sass/ngNotificationsBar.scss
@@ -1,4 +1,4 @@
-@import "../bower_components/hmps-animate-scss/animate.scss";
+@import "../../hmps-animate-scss/animate.scss";
 
 .notifications {
 	.notifications-container {


### PR DESCRIPTION
this was causing problems being nested in too deep.
```
Error: File to import not found or unreadable: ../bower_components/hmps-animate-scss/animate.scss.
        on line 1 of bower_components/ng-notifications-bar/sass/ngNotificationsBar.scss
```