### PR TITLE
Allow using newer versions of Angular

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,9 +28,9 @@
   "dependencies": {
     "angular": ">= 1.2.25",
     "hmps-animate-scss": "~1.0.1",
-    "angular-sanitize": "~1.3.12"
+    "angular-sanitize": ">= 1.3.12"
   },
   "devDependencies": {
-    "angular-mocks": "~1.2.25"
+    "angular-mocks": ">= 1.2.25"
   }
 }


### PR DESCRIPTION
Additonal fix for https://github.com/alexbeletsky/ng-notifications-bar/issues/10 - now bumping version for other components of Angular.